### PR TITLE
EN-3710 address update issues

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,12 +99,13 @@ for funcdir in "${FUNCDIRS[@]}"; do
           echo "Function ${funcdir} differs from deployed SHA ${deployed_sha} in ${location}; redeploying"
           echo "Patch data:"
           gcloud --project="${PROJECT_ID}" functions describe --region "${location}" "${funcdir}" --format=json | \
-            jq -M 'del(.sourceRepository.deployedUrl)' | tee "/tmp/${funcdir}_request.json"
+            jq -M 'del(.sourceRepository.deployedUrl, .buildId, .status, .updateTime, .versionId, .httpsTrigger.url)' | \
+            tee "/tmp/${funcdir}_request.json"
           RESPONSE="$(curl -fs \
             -H "Authorization: Bearer ${ACCESS_TOKEN}" \
             -H "Content-Type: application/json" \
             -X PATCH \
-            "https://cloudfunctions.googleapis.com/v1/projects/${PROJECT_ID}/locations/${location}/functions/${funcdir}?updateMask=sourceRepository.url" \
+            "https://cloudfunctions.googleapis.com/v1/projects/${PROJECT_ID}/locations/${location}/functions/${funcdir}?updateMask=sourceRepository" \
             -d "@/tmp/${funcdir}_request.json")"
           echo "Response:"
           jq -M <<<"${RESPONSE}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,7 +92,7 @@ for funcdir in "${FUNCDIRS[@]}"; do
       fi
       readarray -td/ deployed_url <<<"$deployed_url"
       deployed_sha="${deployed_url[8]}"
-      echo "Checking function ${funcdir} in location ${location} is at sha ${deployed_sha}"
+      echo "Function ${funcdir} in location ${location} is deployed at sha '${deployed_sha}'; github is at '${GITHUB_SHA}'"
       if [[ "${deployed_sha}" != "${GITHUB_SHA}" ]]; then
         # if our current rev has a diff to the deployed rev, we must redeploy
         if ! git diff --quiet "${deployed_sha}" -- "${funcdir}"; then


### PR DESCRIPTION
This is a semi-educated stab at solving the weird behavior we're seeing around function updates,
wherein manual updates of the function in the console (no options changed, just edit->submit) cause
the function to correctly resolve the correct branch->ref relationship but where our calls to the API
result in the old ref being retained.

- strip all read-only fields from the function JSON doc before passing it back to the [PATCH API](https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/patch)

- pass the entire `sourceRepository` key to the `updateMask` parameter rather than just the `.url` sub-key.